### PR TITLE
fix: regex for filters failed (#92)

### DIFF
--- a/v3/worker.js
+++ b/v3/worker.js
@@ -96,7 +96,7 @@ const store = async (d, type, size = '') => {
     store.check = store.prefs.blacklist.length ? new RegExp(store.prefs.blacklist.join('|')) : false;
   }
 
-  if (store.check && store.check.test(d.href)) {
+  if (store.check && store.check.test(d.url)) {
     return;
   }
 


### PR DESCRIPTION
After quick debugging I found out that the store check failed because the field `href` doesn't exist anymore in the `d`-object

```json
{
    "documentId": "1B4297BDAF5C7BE71F7AC91C168A5A95",
    "documentLifecycle": "active",
    "frameId": 250,
    "frameType": "sub_frame",
    "initiator": "https://nathanfromsubject.com",
    "method": "GET",
    "parentDocumentId": "46B7B82F7E5D06DD9D7B2D9EB985E75E",
    "parentFrameId": 0,
    "requestId": "2780",
    "responseHeaders": [...],
    "statusCode": 200,
    "statusLine": "HTTP/1.1 200 OK",
    "tabId": 189817494,
    "timeStamp": 1744307256480.382,
    "type": "xmlhttprequest",
    "url": "https://cdn-dzlrqbh8qr5lcobm.orbitcache.com/engine/hls2-c/01/08966/ucli91gpir7z_,n,.urlset/seg-1-v1-a1.ts?t=zMv-7waowZTyYRkwM3KUadTUGtVAhhlB1wsG_VRwXu4&s=1744307256&e=14400&f=56609636&node=I1EQvlHafoJM/zWmWqVFTvVK5jRXu9gJkhTSUBO5LCk=&i=185.253&sp=2500&asn=64476&q=n&rq=hqHzdFMOZRvxqXcSBDOpohkWfkEBi1PA2SznHv31"
}
```

Changed the `d.href` to `d.url`. Now filters/blacklist is working again. (Fixes #92 )